### PR TITLE
Identity2 parse

### DIFF
--- a/Communications.lua
+++ b/Communications.lua
@@ -332,6 +332,7 @@ end
 
 local function ParseGuildChatCommands(text)
 	if UnitLevel('player') ~= e.EXPANSION_LEVEL then return end -- Don't bother checking anything if the unit is unable to acquire a key
+	text = gsub(text, "^%[%a+%] ", "") -- Strip off [SomeName] from message from using Identity-2
 	if text == '!keys' then
 		local guild = GetGuildInfo('player')
 		if AstralKeysSettings.general.report_on_message['guild'] or (guild == 'Astral' and e.PlayerRealm() == 'Turalyon') then -- Guild leader for Astral desires this setting to be foreced on for members.
@@ -352,6 +353,7 @@ AstralEvents:Register('CHAT_MSG_GUILD', ParseGuildChatCommands, 'parseguildchat'
 
 local function ParsePartyChatCommands(text)
 	if UnitLevel('player') ~= e.EXPANSION_LEVEL then return end -- Don't bother checking anything if the unit is unable to acquire a key
+	text = gsub(text, "^%[%a+%] ", "") -- Strip off [SomeName] from message from using Identity-2
 	if text == '!keys' then
 		if AstralKeysSettings.general.report_on_message['party'] then
 			local unitID = e.UnitID(e.Player())
@@ -372,6 +374,7 @@ AstralEvents:Register('CHAT_MSG_PARTY_LEADER', ParsePartyChatCommands, 'parsepar
 
 local function ParseRaidChatCommands(text)
 	if UnitLevel('player') ~= e.EXPANSION_LEVEL then return end -- Don't bother checking anything if the unit is unable to acquire a key
+	text = gsub(text, "^%[%a+%] ", "") -- Strip off [SomeName] from message from using Identity-2
 	if text == '!keys' then
 		if AstralKeysSettings.general.report_on_message['raid'] then
 			local unitID = e.UnitID(e.Player())


### PR DESCRIPTION
Strip off `[Name] ` at the beginning so it works with the Identity2 addon

A bunch of my guildmates use Identity2 to show who they are and we noticed it wouldn't pick it up if you didn't turn it off when doing the command. This strips that out so it can respond to `!keys` without having to disable it to send the command and then turn it back on.